### PR TITLE
Bits for adding an additional commit message

### DIFF
--- a/R/api-bump-version.R
+++ b/R/api-bump-version.R
@@ -5,8 +5,8 @@
 #'
 #' @inheritParams update_version
 #' @export
-bump_version <- function(which = "dev") {
+bump_version <- function(which = "dev", additional_commit_message = "") {
   check_which(which)
   check_clean(c("DESCRIPTION", "NEWS.md"))
-  bump_version_impl(which)
+  bump_version_impl(which, additional_commit_message)
 }

--- a/R/api-commit-version.R
+++ b/R/api-commit-version.R
@@ -4,8 +4,8 @@
 #' created by \pkg{fledge} if necessary.
 #'
 #' @export
-commit_version <- function() {
-  amending <- commit_version_impl()
+commit_version <- function(additional_commit_message = "") {
+  amending <- commit_version_impl(additional_commit_message)
 
   #' @return Invisibly: `TRUE` if a previous commit for that version has been
   #'   amended, `FALSE` if not.

--- a/R/bump-version.R
+++ b/R/bump-version.R
@@ -1,6 +1,6 @@
 #' @rdname bump_version
 #' @usage NULL
-bump_version_impl <- function(which) {
+bump_version_impl <- function(which, additional_commit_message = "") {
   #' @description
   #' 1. [update_news()]
   update_news()
@@ -9,14 +9,14 @@ bump_version_impl <- function(which) {
   #' 3. Depending on the `which` argument:
   if (which == "dev") {
   #'     - If `"dev"`, [finalize_version()]
-    finalize_version_impl()
+    finalize_version_impl(additional_commit_message)
     edit_news()
     ui_todo("If you have updated {ui_path('NEWS.md')}, save the file and call {ui_code('fledge::finalize_version()')}")
     ui_todo("When done, push to the remote repository, including tags.")
     ui_info("Use {ui_code('git push --tags')} from the command line.")
   } else {
   #'     - Otherwise, [commit_version()].
-    commit_version()
+    commit_version(additional_commit_message)
     ui_info("Preparing package for release (CRAN or otherwise)")
     edit_news()
     ui_todo("Every time you edit {ui_path('NEWS.md')}, save it and call {ui_code('fledge::commit_version()')}")

--- a/R/commit-version.R
+++ b/R/commit-version.R
@@ -1,4 +1,4 @@
-commit_version_impl <- function() {
+commit_version_impl <- function(additional_commit_message = "") {
   check_only_staged(c("DESCRIPTION", "NEWS.md"))
 
   if (is_last_commit_bump()) {
@@ -12,7 +12,11 @@ commit_version_impl <- function() {
   git2r::add(".", c("DESCRIPTION", "NEWS.md"))
   if (length(git2r::status(".", unstaged = FALSE, untracked = FALSE)$staged) > 0) {
     ui_info("Committing changes")
-    git2r::commit(".", get_commit_message())
+    if (additional_commit_message != "") {
+      git2r::commit(".", get_commit_message())
+    } else {
+      git2r::commit(".", sprintf("%s - %s", additional_commit_message, get_commit_message()))
+    }
   }
 
   amending

--- a/R/finalize-version.R
+++ b/R/finalize-version.R
@@ -1,9 +1,9 @@
 #' @rdname finalize_version
 #' @usage NULL
-finalize_version_impl <- function() {
+finalize_version_impl <- function(additional_commit_message = "") {
   #' @description
   #' 1. [commit_version()]
-  force <- commit_version()
+  force <- commit_version(additional_commit_message)
   #' 1. [tag_version()], setting `force = TRUE` if and only if `commit_version()`
   #'   amended a commit.
   tag_version(force)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ below.
     
     Substitute `"patch"` by `"minor"` or `"major"` if applicable.
 
+  - To add an additional bit to the commit message (like `[skip ci]` for use in CircleCI, etc...)
+    CRAN, use
+    
+    ``` r
+    fledge::bump_version("patch", "[skip ci]")
+    fledge::commit_version()
+    ```
+
   - To tag a version when the package has been accepted to CRAN, use
     
     ``` r


### PR DESCRIPTION
This fixes #24 , allowing you to add an additional commit message that will be prepended to the git commit generated by this project. This is helpful for use in CircleCI at the minimum, if that commit is pushed in to the repo, it can inform CircleCI to skip a build on it.

Let me know your thoughts!